### PR TITLE
Fix trailing slash issue in regex

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -182,8 +182,6 @@ class Launcher {
                 const url = matches?.[1];
                 if (url) {
                     resolve({ url, stop });
-                } else {
-                    // console.log(`did not match`);
                 }
             });
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -42,7 +42,7 @@ interface IWebInstance extends IInstance {
 
 class Launcher {
 
-    private static readonly WEB_AVAILABLE_REGEX = new RegExp('Web UI available at (http://localhost:8000/\\?tkn=.+)');
+    private static readonly WEB_AVAILABLE_REGEX = new RegExp('Web UI available at (http://localhost:8000/?\\?tkn=.+)');
 
     static {
 
@@ -182,6 +182,8 @@ class Launcher {
                 const url = matches?.[1];
                 if (url) {
                     resolve({ url, stop });
+                } else {
+                    // console.log(`did not match`);
                 }
             });
 


### PR DESCRIPTION
The web ui doesn't always print a trailing slash