### PR TITLE
Add exploration quality support

### DIFF
--- a/src/builds.ts
+++ b/src/builds.ts
@@ -6,7 +6,7 @@
 import chalk from 'chalk';
 import { dirname, join } from 'node:path';
 import { rmSync } from 'node:fs';
-import { Arch, arch, Flavor, isDockerCliFlavor, LOGGER, Platform, platform, Quality, Runtime } from './constants.js';
+import { Arch, arch, Flavor, isDockerCliFlavor, LOGGER, Platform, platform, Quality, qualityCommandSuffix, qualityDisplayLabel, Runtime } from './constants.js';
 import { fileGet, jsonGet } from './fetch.js';
 import { computeSHA256, exists, getBuildPath, unzip } from './files.js';
 
@@ -30,12 +30,8 @@ interface IBuildMetadata {
 class Builds {
 
     async fetchBuildByVersion({ runtime, quality, flavor }: IBuildKind, version: string): Promise<IBuild> {
-        let meta;
-        if (quality === 'insider') {
-            meta = await jsonGet<IBuildMetadata>(`https://update.code.visualstudio.com/api/versions/${version}.0-insider/${this.getBuildApiName({ runtime, quality, flavor })}/insider?released=true`);
-        } else {
-            meta = await jsonGet<IBuildMetadata>(`https://update.code.visualstudio.com/api/versions/${version}.0/${this.getBuildApiName({ runtime, quality, flavor })}/stable?released=true`);
-        }
+        const versionStr = quality === Quality.Stable ? `${version}.0` : `${version}.0-${quality}`;
+        const meta = await jsonGet<IBuildMetadata>(`https://update.code.visualstudio.com/api/versions/${versionStr}/${this.getBuildApiName({ runtime, quality, flavor })}/${quality}?released=true`);
 
         return { runtime, commit: meta.version, quality, flavor };
     }
@@ -281,8 +277,10 @@ class Builds {
         if (flavor !== Flavor.Cli) {
             switch (platform) {
                 case Platform.MacOSX64:
-                case Platform.MacOSArm:
-                    return quality === 'insider' ? 'Visual Studio Code - Insiders.app' : 'Visual Studio Code.app';
+                case Platform.MacOSArm: {
+                    const label = qualityDisplayLabel(quality);
+                    return label ? `Visual Studio Code - ${label}.app` : 'Visual Studio Code.app';
+                }
                 case Platform.LinuxX64:
                 case Platform.LinuxArm:
                     return `VSCode-linux-${arch}`;
@@ -296,7 +294,7 @@ class Builds {
         }
 
         // CLI
-        return quality === 'insider' ? 'code-insiders' : 'code';
+        return `code${qualityCommandSuffix(quality)}`;
     }
 
     private fetchBuildMeta({ runtime, commit, quality, flavor }: IBuild): Promise<IBuildMetadata> {
@@ -383,7 +381,7 @@ class Builds {
                         return oldLocation; // only valid until 1.64.x
                     }
 
-                    return join(buildPath, buildName, 'bin', quality === 'insider' ? 'code-server-insiders' : 'code-server');
+                    return join(buildPath, buildName, 'bin', `code-server${qualityCommandSuffix(quality)}`);
                 }
                 case Platform.WindowsX64:
                 case Platform.WindowsArm: {
@@ -392,7 +390,7 @@ class Builds {
                         return oldLocation; // only valid until 1.64.x
                     }
 
-                    return join(buildPath, buildName, buildName, 'bin', quality === 'insider' ? 'code-server-insiders.cmd' : 'code-server.cmd');
+                    return join(buildPath, buildName, buildName, 'bin', `code-server${qualityCommandSuffix(quality)}.cmd`);
                 }
             }
         }
@@ -402,7 +400,8 @@ class Builds {
             switch (platform) {
                 case Platform.MacOSX64:
                 case Platform.MacOSArm: {
-                    const newLocation = join(buildPath, buildName, 'Contents', 'MacOS', quality === 'insider' ? 'Code - Insiders' : 'Code');
+                    const label = qualityDisplayLabel(quality);
+                    const newLocation = join(buildPath, buildName, 'Contents', 'MacOS', label ? `Code - ${label}` : 'Code');
                     if (await exists(newLocation)) {
                         return newLocation; // valid from 1.110 onwards
                     }
@@ -410,10 +409,12 @@ class Builds {
                 }
                 case Platform.LinuxX64:
                 case Platform.LinuxArm:
-                    return join(buildPath, buildName, quality === 'insider' ? 'code-insiders' : 'code')
+                    return join(buildPath, buildName, `code${qualityCommandSuffix(quality)}`)
                 case Platform.WindowsX64:
-                case Platform.WindowsArm:
-                    return join(buildPath, buildName, quality === 'insider' ? 'Code - Insiders.exe' : 'Code.exe');
+                case Platform.WindowsArm: {
+                    const label = qualityDisplayLabel(quality);
+                    return join(buildPath, buildName, label ? `Code - ${label}.exe` : 'Code.exe');
+                }
             }
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,11 +31,12 @@ export const PERFORMANCE_RUNS = 10;
 export const PERFORMANCE_RUN_TIMEOUT = 60000;
 
 export const VSCODE_DEV_URL = function (commit: string, quality: Quality) {
+    const prefix = quality === Quality.Insider ? 'insiders.' : quality === Quality.Exploration ? 'exploration.' : '';
     if (CONFIG.token) {
-        return `https://${quality === Quality.Insider ? 'insiders.' : ''}vscode.dev/github/microsoft/vscode/blob/main/package.json?vscode-version=${commit}`; // with auth state, we can use `github` route
+        return `https://${prefix}vscode.dev/github/microsoft/vscode/blob/main/package.json?vscode-version=${commit}`; // with auth state, we can use `github` route
     }
 
-    return `https://${quality === Quality.Insider ? 'insiders.' : ''}vscode.dev/?vscode-version=${commit}`;
+    return `https://${prefix}vscode.dev/?vscode-version=${commit}`;
 }
 
 export enum Arch {
@@ -101,7 +102,8 @@ export function runtimeFromString(value: unknown): Runtime {
 
 export enum Quality {
     Insider = 'insider',
-    Stable = 'stable'
+    Stable = 'stable',
+    Exploration = 'exploration'
 }
 
 export function qualityFromString(value: unknown): Quality {
@@ -110,12 +112,30 @@ export function qualityFromString(value: unknown): Quality {
             return Quality.Stable;
         case 'insider':
             return Quality.Insider;
+        case 'exploration':
+            return Quality.Exploration;
         default: {
             if (typeof value === 'string') {
                 throw new Error(`Unknown quality: ${value}`);
             }
             return Quality.Insider;
         }
+    }
+}
+
+export function qualityCommandSuffix(quality: Quality): string {
+    switch (quality) {
+        case Quality.Insider: return '-insiders';
+        case Quality.Exploration: return '-exploration';
+        case Quality.Stable: return '';
+    }
+}
+
+export function qualityDisplayLabel(quality: Quality): string | undefined {
+    switch (quality) {
+        case Quality.Insider: return 'Insiders';
+        case Quality.Exploration: return 'Exploration';
+        case Quality.Stable: return undefined;
     }
 }
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -30,8 +30,8 @@ export function getBuildPath(commit: string, quality: Quality, flavor: Flavor): 
     }
 
     const prefixes: string[] = [];
-    if (quality === Quality.Stable) {
-        prefixes.push('stable');
+    if (quality !== Quality.Insider) {
+        prefixes.push(quality);
     }
 
     if (flavor !== Flavor.Default) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export default async function main(argv: string[]): Promise<void> {
             runtime?: 'web' | 'desktop' | 'vscode.dev';
             commit?: string;
             version?: string;
-            quality?: 'insider' | 'stable';
+            quality?: 'insider' | 'stable' | 'exploration';
             flavor?: string;
             good?: string;
             bad?: string;
@@ -44,7 +44,7 @@ export default async function main(argv: string[]): Promise<void> {
             .addOption(new Option('-r, --runtime <desktop|web|vscode.dev>', 'whether to bisect with a local web, online vscode.dev or local desktop (default) version').choices(['desktop', 'web', 'vscode.dev']))
             .option('-c, --commit <commit|latest>', 'commit hash of a published build to test or "latest" released build (supercedes -g and -b)')
             .option('-v, --version <major.minor>', 'version of a published build to test, for example 1.93 (supercedes -g, -b and -c)')
-            .addOption(new Option('-q, --quality <insider|stable>', 'quality of a published build to test, defaults to "insider"').choices(['insider', 'stable']))
+            .addOption(new Option('-q, --quality <insider|stable|exploration>', 'quality of a published build to test, defaults to "insider"').choices(['insider', 'stable', 'exploration']))
             .addOption(new Option('-f, --flavor <flavor>', 'flavor of a published build to test (only applies when testing desktop builds)').choices(['universal', 'cli', 'win32-user', 'win32-system', 'linux-deb', 'linux-rpm', 'linux-snap', 'cli-linux-amd64', 'cli-linux-arm64', 'cli-linux-armv7', 'cli-alpine-amd64', 'cli-alpine-arm64']))
             .option('-g, --good <commit|version>', 'commit hash or version of a published build that does not reproduce the issue')
             .option('-b, --bad <commit|version>', 'commit hash or version of a published build that reproduces the issue')

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -16,7 +16,7 @@ import kill from 'tree-kill';
 import chalk from 'chalk';
 import * as perf from '@vscode/vscode-perf';
 import { builds, IBuild } from './builds.js';
-import { CONFIG, DATA_FOLDER, EXTENSIONS_FOLDER, GIT_VSCODE_FOLDER, LOGGER, DEFAULT_PERFORMANCE_FILE, Platform, platform, Runtime, USER_DATA_FOLDER, VSCODE_DEV_URL, Flavor, Quality, isDockerCliFlavor } from './constants.js';
+import { CONFIG, DATA_FOLDER, EXTENSIONS_FOLDER, GIT_VSCODE_FOLDER, LOGGER, DEFAULT_PERFORMANCE_FILE, Platform, platform, Runtime, USER_DATA_FOLDER, VSCODE_DEV_URL, Flavor, Quality, isDockerCliFlavor, qualityCommandSuffix, qualityDisplayLabel } from './constants.js';
 import { exists } from './files.js';
 
 export interface IInstance {
@@ -116,22 +116,23 @@ class Launcher {
     }
 
     private async runLinuxDesktopInstaller(quality: Quality, flavor: Flavor.LinuxDeb | Flavor.LinuxRPM | Flavor.LinuxSnap, path: string): Promise<IInstance | undefined> {
+        const commandName = `code${qualityCommandSuffix(quality)}`;
         let installCommand: string;
         let executeCommand: string;
         let executeArgs: string[] | undefined = undefined;
         switch (flavor) {
             case Flavor.LinuxDeb:
-                installCommand = `sudo dpkg -r ${quality === 'stable' ? 'code' : 'code-insiders'} && sudo dpkg -i ${path}`;
-                executeCommand = quality === 'stable' ? 'code' : 'code-insiders';
+                installCommand = `sudo dpkg -r ${commandName} && sudo dpkg -i ${path}`;
+                executeCommand = commandName;
                 break;
             case Flavor.LinuxRPM:
-                installCommand = `sudo rpm -e ${quality === 'stable' ? 'code' : 'code-insiders'} && sudo rpm -i ${path}`;
-                executeCommand = quality === 'stable' ? 'code' : 'code-insiders';
+                installCommand = `sudo rpm -e ${commandName} && sudo rpm -i ${path}`;
+                executeCommand = commandName;
                 break;
             case Flavor.LinuxSnap:
-                installCommand = `sudo snap remove ${quality === 'stable' ? 'code' : 'code-insiders'} && sudo snap install ${path} --classic --dangerous`;
+                installCommand = `sudo snap remove ${commandName} && sudo snap install ${path} --classic --dangerous`;
                 executeCommand = 'snap';
-                executeArgs = ['run', quality === 'stable' ? 'code' : 'code-insiders'];
+                executeArgs = ['run', commandName];
                 break;
         }
 
@@ -192,7 +193,6 @@ class Launcher {
 
     private getWindowsVSCodeExecutablePath(flavor: Flavor.WindowsUserInstaller | Flavor.WindowsSystemInstaller, quality: Quality): string {
         const isUserInstaller = flavor === Flavor.WindowsUserInstaller;
-        const isInsiders = quality === Quality.Insider;
 
         // Determine base directory
         let baseDir: string;
@@ -206,15 +206,9 @@ class Launcher {
             baseDir = programFiles;
         }
 
-        let appFolder: string;
-        let executableName: string;
-        if (isInsiders) {
-            appFolder = 'Microsoft VS Code Insiders';
-            executableName = 'code-insiders.cmd';
-        } else {
-            appFolder = 'Microsoft VS Code';
-            executableName = 'code.cmd';
-        }
+        const label = qualityDisplayLabel(quality);
+        const appFolder = label ? `Microsoft VS Code ${label}` : 'Microsoft VS Code';
+        const executableName = `code${qualityCommandSuffix(quality)}.cmd`;
 
         return join(baseDir, appFolder, 'bin', executableName);
     }
@@ -392,7 +386,7 @@ class Launcher {
 
     private async launchDockerCLI(build: IBuild, flavor: Flavor.CliLinuxAmd64 | Flavor.CliLinuxArm64 | Flavor.CliLinuxArmv7 | Flavor.CliAlpineAmd64 | Flavor.CliAlpineArm64): Promise<IInstance> {
         const commit = build.commit;
-        const quality = build.quality === Quality.Insider ? 'insider' : 'stable';
+        const quality = build.quality;
 
         await this.setupDockerBinfmt();
 

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -24,7 +24,7 @@ if (platform === Platform.MacOSArm || platform === Platform.MacOSX64) {
 }
 
 const buildKinds: IBuildKind[] = [];
-for (const quality of [Quality.Stable, Quality.Insider]) {
+for (const quality of [Quality.Stable, Quality.Insider, Quality.Exploration]) {
     for (const flavor of platformFlavors) {
         for (const runtime of [Runtime.DesktopLocal, Runtime.WebLocal]) {
             if (flavor !== Flavor.Default && runtime === Runtime.WebLocal) {


### PR DESCRIPTION
Adds `Quality.Exploration` support following the same pattern as the existing `Quality.Insider` implementation.

### Changes

- **`constants.ts`**: Added `Exploration = 'exploration'` to the `Quality` enum, added `'exploration'` case to `qualityFromString`, updated `VSCODE_DEV_URL` for `exploration.vscode.dev`, and introduced two helper functions (`qualityCommandSuffix`, `qualityDisplayLabel`) to reduce duplication across files
- **`builds.ts`**: Updated `fetchBuildByVersion` URL construction, app names (`Visual Studio Code - Exploration.app`), executable names (`code-exploration`, `code-server-exploration`, `Code - Exploration.exe`), and CLI names using the new helpers
- **`launcher.ts`**: Updated Linux installer package names, Windows installer paths, and Docker CLI quality parameter to handle exploration
- **`files.ts`**: Updated `getBuildPath` to add `exploration` prefix for exploration builds
- **`index.ts`**: Added `'exploration'` to CLI `--quality` option choices
- **`integration.test.ts`**: Added `Quality.Exploration` to test iteration