### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ npx @vscode/vscode-bisect --help
 ```
 
 `@vscode/vscode-bisect` is meant to be only used as a command line tool.
+
+## Contributors
+
+- [bpasero](https://github.com/bpasero)


### PR DESCRIPTION
## Summary

Adds a **Contributors** section to the README with a link to [@bpasero](https://github.com/bpasero)'s GitHub profile.

## Changes

- Added a new "Contributors" section at the bottom of `README.md`
- Listed `bpasero` as a contributor with a GitHub profile link